### PR TITLE
fix: all commands go through the queue

### DIFF
--- a/Tesira-DSP-EPI/TesiraDsp.cs
+++ b/Tesira-DSP-EPI/TesiraDsp.cs
@@ -744,9 +744,8 @@ namespace Tesira_DSP_EPI
                 else if (args.Text.IndexOf("+OK", StringComparison.Ordinal) == 0)
                 {
                     if(InitialStart) CheckSerialSendStatus();
-                    if (args.Text == "+OK")       // Check for a simple "+OK" only 'ack' repsonse or a list response and ignore
-
-                        return;
+                    // if (args.Text == "+OK")       // Check for a simple "+OK" only 'ack' repsonse or a list response and ignore
+                       // return;
                     
                     // response is not from a subscribed attribute.  From a get/set/toggle/increment/decrement command
                     //string pattern = "(?<=\" )(.*?)(?=\\+)";

--- a/Tesira-DSP-EPI/TesiraDspControlPoint.cs
+++ b/Tesira-DSP-EPI/TesiraDspControlPoint.cs
@@ -153,18 +153,20 @@ namespace Tesira_DSP_EPI
             }
 
 
-			if (command == "get")
-			{
-				// This command will generate a return value response so it needs to be queued
-				if (!string.IsNullOrEmpty(cmd))
-                    Parent.CommandQueue.EnqueueCommand(new QueuedCommand(cmd, attributeCode, this));
-			}
-			else
-			{
-				// This command will generate a simple "+OK" response and doesn't need to be queued
-				if (!string.IsNullOrEmpty(cmd))
-                    Parent.SendLine(cmd);
-			}
+            //if (command == "get")
+            //{
+            //    // This command will generate a return value response so it needs to be queued
+            //    if (!string.IsNullOrEmpty(cmd))
+            //        Parent.CommandQueue.EnqueueCommand(new QueuedCommand(cmd, attributeCode, this));
+            //}
+            //else
+            //{
+            //    // This command will generate a simple "+OK" response and doesn't need to be queued
+            //    if (!string.IsNullOrEmpty(cmd))
+            //        Parent.SendLine(cmd);
+            //}
+
+            Parent.CommandQueue.EnqueueCommand(new QueuedCommand(cmd, attributeCode, this));
 		}
 
 		virtual public void ParseGetMessage(string attributeCode, string message)

--- a/Tesira-DSP-EPI/TesiraDspRouter.cs
+++ b/Tesira-DSP-EPI/TesiraDspRouter.cs
@@ -188,7 +188,7 @@ namespace Tesira_DSP_EPI {
 
                 if (message.Contains("-ERR address not found"))
                 {
-                    Debug.ConsoleWithLog(2, this, "Baimp Error Address not found: '{0}'\n", InstanceTag1);
+                    Debug.ConsoleWithLog(2, this, "Biamp Error Address not found: '{0}'\n", InstanceTag1);
                     return;
                 }
 


### PR DESCRIPTION
There were some instances where any command that responded with a `+OK` and not a value bypassed the command queue. This caused issues, as the subsequent `GET` command to update feedback for a router output WAS enqueued, and responses from subsequent `SET` responses were stepping on the `+OK 0` responses to the `GET` commands. This is especially apparent on RS-232 connections, and probably doesn't present as an issue for SSH connections.

fixes #89