### PR TITLE
Hotfix/fader outside min max

### DIFF
--- a/src/Tesira-DSP-EPI.4Series.csproj
+++ b/src/Tesira-DSP-EPI.4Series.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<ProjectType>ProgramLibrary</ProjectType>
 	</PropertyGroup>
@@ -25,6 +25,10 @@
 		<DefineConstants>$(DefineConstants);SERIES4</DefineConstants>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+	  <DefineConstants>$(DefineConstants);SERIES4</DefineConstants>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<Compile Remove="Properties\**" />
 		<EmbeddedResource Remove="Properties\**" />
@@ -36,7 +40,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="PepperDashEssentials" Version="2.1.0" >
+		<PackageReference Include="PepperDashEssentials" Version="2.1.0">
 			<ExcludeAssets>runtime</ExcludeAssets>
-		</PackageReference>	</ItemGroup>
+		</PackageReference>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
verified working on live system.  Faders now can set to 0% and 100% without going over as well as ramped up and down without causing exception.