### PR TITLE
fix: serialization of TesiraPreset works correctly

### DIFF
--- a/src/TesiraDsp.cs
+++ b/src/TesiraDsp.cs
@@ -1363,8 +1363,7 @@ namespace Tesira_DSP_EPI
 				}
 
 				var dialerLineOffset = lineOffset;
-                this.LogVerbose("AddingDialerBRidge {0} {1} Offset", dialer.Key, dialerLineOffset);
-
+                this.LogVerbose("AddingDialerBridge {0} {1} Offset", dialer.Key, dialerLineOffset);
                 for (var i = 0; i < dialerJoinMap.KeyPadNumeric.JoinSpan; i++)
                 {
 					var tempi = i;

--- a/src/TesiraDspFaderControl.cs
+++ b/src/TesiraDspFaderControl.cs
@@ -13,11 +13,8 @@ using Tesira_DSP_EPI.Interfaces;
 
 namespace Tesira_DSP_EPI
 {
-    public class TesiraDspFaderControl : TesiraDspControlPoint, 
-        IBasicVolumeWithFeedback,
-#if SERIES4
+    public class TesiraDspFaderControl : TesiraDspControlPoint,
         IBasicVolumeWithFeedbackAdvanced,
-#endif
         IVolumeComponent
     {
         private bool _isMuted;
@@ -126,7 +123,6 @@ namespace Tesira_DSP_EPI
         /// </summary>
         public bool HasLevel { get; private set; }
 
-#if SERIES4
         public int RawVolumeLevel { get; private set; }
 
         public eVolumeLevelUnits Units
@@ -136,7 +132,7 @@ namespace Tesira_DSP_EPI
                 return eVolumeLevelUnits.Decibels;
             }
         }
-#endif     
+     
 
         /// <summary>
         /// Constructor for Component
@@ -330,9 +326,9 @@ namespace Tesira_DSP_EPI
             else if (HasLevel && customName == LevelCustomName)
             {
                 var localValue = Double.Parse(value);
-#if SERIES4
+
                 RawVolumeLevel = (int)localValue;
-#endif
+
                 VolumeLevel = UseAbsoluteValue ? (ushort)localValue :  (ushort)localValue.Scale(MinLevel, MaxLevel, 0, 65535, this);
 
                 SubscriptionTracker["level"].Subscribed = true;
@@ -385,9 +381,9 @@ namespace Tesira_DSP_EPI
                     case "level":
                     {
                         var localValue = Double.Parse(value);
-#if SERIES4
+
                         RawVolumeLevel = (int) localValue; 
-#endif
+
                         VolumeLevel = UseAbsoluteValue ? (ushort) localValue : (ushort)localValue.Scale(MinLevel, MaxLevel, 0, 65535, this);
 
                         Debug.Console(1, this, "VolumeLevel is '{0}'", VolumeLevel);

--- a/src/TesiraDspPreset.cs
+++ b/src/TesiraDspPreset.cs
@@ -9,12 +9,8 @@ using PepperDash.Essentials.Core.Bridges;
 
 namespace Tesira_DSP_EPI
 {
-    public class TesiraDspPresetDevice : TesiraDspControlPoint,
-        #if SERIES4
-        IDspPresets
-#else
-        IHasDspPresets
-#endif
+    public class TesiraDspPresetDevice : TesiraDspControlPoint, IDspPresets       
+
     {
         private const string KeyFormatter = "{0}--{1}";
 
@@ -29,11 +25,7 @@ namespace Tesira_DSP_EPI
 
         #region IHasDspPresets Members
 
-#if SERIES4
         public Dictionary<string, IKeyName> Presets { get; private set; }
-#else
-        public List<IDspPreset> Presets { get; set; }
-#endif
 
         #endregion
 
@@ -72,9 +64,9 @@ namespace Tesira_DSP_EPI
             {
                 var p = preset.Value as TesiraPreset;
                 if (p == null) continue;
-                var runPresetIndex = p.PresetData.PresetIndex;
+                var runPresetIndex = p.PresetIndex;
                 var presetIndex = runPresetIndex;
-                trilist.StringInput[(uint)(presetJoinMap.PresetNameFeedback.JoinNumber + presetIndex - 1)].StringValue = p.PresetData.PresetName;
+                trilist.StringInput[(uint)(presetJoinMap.PresetNameFeedback.JoinNumber + presetIndex - 1)].StringValue = p.PresetName;
                 trilist.SetSigTrueAction((uint)(presetJoinMap.PresetSelection.JoinNumber + presetIndex - 1),
                     () => RecallPreset(p.Key));
             }
@@ -123,21 +115,10 @@ namespace Tesira_DSP_EPI
             //CommandQueue.EnqueueCommand(string.Format("DEVICE recallPreset {0}", id));
         }
 
-
-#if SERIES4
         public void RecallPreset(string key)
         {
             Parent.RecallPreset(key);
         }
-#else
-        public void RecallPreset(IDspPreset preset)
-        {
-            Parent.RecallPreset(preset);
-        }
-#endif
-
-
-
 
         #endregion
 
@@ -146,19 +127,12 @@ namespace Tesira_DSP_EPI
     public class TesiraPreset : TesiraDspPresets, IKeyName
     {
         public string Key { get; private set; }
-        public string Name { get; private set; }
-        public int Index { get; private set; }
+        public string Name => Label;
+        public int Index => PresetIndex;
 
-        public TesiraDspPresets PresetData { get; private set; }
-
-        public TesiraPreset(string key, TesiraDspPresets data)
+        public TesiraPreset(string key):base()
         {
             Key = key;
-            PresetData = data;
-            Name = data.Label;
-            Index = data.PresetIndex;
-
-            Debug.Console(1, "Tesira PresetData = {0} , {1}, {2}", PresetData.PresetName, PresetData.PresetId, PresetData.PresetIndex);
         }
     }
 

--- a/src/TesiraDspPropertiesConfig.cs
+++ b/src/TesiraDspPropertiesConfig.cs
@@ -279,6 +279,7 @@ namespace Tesira_DSP_EPI {
         [JsonProperty("presetIndex")]
         public int PresetIndex { get; set; }
 
+        [JsonIgnore]
         public StringFeedback LabelFeedback;
 
         public TesiraDspPresets()


### PR DESCRIPTION
The `TesiraPreset` class inherits from the `TesiraDspPresets` class,
which has a `StringFeedback` for use with bridging to SIMPL. The
feedback was causing serialization issues when attempting to send
presets to a React application via MC.

The `TesiraPreset` class also had an extra `TesiraDspPresets` type that
wasn't necassary, since the class inherits from `TesiraDspPresets` and
has all the same properties due to the inheritance.

The `SERIES4` directive was removed, and the log statements in the `TesiraDsp` class and the `TesiraDspPreset` class were changed to use the extension methods.
