### PR TITLE
logic meter add

### DIFF
--- a/src/TesiraDspLogicMeter.cs
+++ b/src/TesiraDspLogicMeter.cs
@@ -77,6 +77,7 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
       if (!bool.TryParse(message, out var newState))
       {
         this.LogError("Failed to parse logic meter state from message: {message}", message);
+        return;
       }
 
       State = newState;

--- a/src/TesiraDspPropertiesConfig.cs
+++ b/src/TesiraDspPropertiesConfig.cs
@@ -2,7 +2,8 @@
 using Newtonsoft.Json;
 using PepperDash.Essentials.Core;
 
-namespace Tesira_DSP_EPI {
+namespace Tesira_DSP_EPI
+{
     public class TesiraDspPropertiesConfig
     {
         public CommunicationMonitorConfig CommunicationMonitorProperties { get; set; }
@@ -39,6 +40,9 @@ namespace Tesira_DSP_EPI {
         [JsonProperty("meterControlBlocks")]
         public Dictionary<string, TesiraMeterBlockConfig> MeterControlBlocks { get; set; }
 
+        [JsonProperty("logicMeterControlBlocks")]
+        public Dictionary<string, TesiraLogicMeterBlockConfig> LogicMeterControlBlocks { get; set; }
+
         [JsonProperty("crosspointStateControlBlocks")]
         public Dictionary<string, TesiraCrosspointStateBlockConfig> CrosspointStateControlBlocks { get; set; }
 
@@ -47,7 +51,7 @@ namespace Tesira_DSP_EPI {
 
         [JsonProperty("tesiraExpanderBlocks")]
         public Dictionary<string, TesiraExpanderBlockConfig> ExpanderBlocks { get; set; }
-        
+
         [JsonProperty("resubscribeString")]
         public string ResubscribeString { get; set; }
     }
@@ -309,6 +313,24 @@ namespace Tesira_DSP_EPI {
         public uint? BridgeIndex { get; set; }
     }
 
+    public class TesiraLogicMeterBlockConfig
+    {
+        [JsonProperty("enabled")]
+        public bool Enabled { get; set; }
+
+        [JsonProperty("label")]
+        public string Label { get; set; }
+
+        [JsonProperty("meterInstanceTag")]
+        public string MeterInstanceTag { get; set; }
+
+        [JsonProperty("index")]
+        public int Index { get; set; }
+
+        [JsonProperty("bridgeIndex")]
+        public uint? BridgeIndex { get; set; }
+    }
+
 
 
     public class MeterMetadata
@@ -347,7 +369,7 @@ namespace Tesira_DSP_EPI {
         public bool PollEnable { get; set; }
 
         [JsonProperty("pollTimeMs")]
-        public long  PollTimeMs { get; set; }
+        public long PollTimeMs { get; set; }
 
 
     }


### PR DESCRIPTION
This pull request adds support for "logic meters" to the Tesira DSP plugin. The main changes include introducing a new `TesiraDspLogicMeter` class, updating configuration to allow specifying logic meters, and integrating logic meter handling throughout the device code. These changes enable the system to monitor and provide feedback on boolean state meters in Tesira DSP devices.

**Logic Meter Support**

* Added the `TesiraDspLogicMeter` class, which handles subscription, feedback, and state for logic meters. This class provides `BoolFeedback` for state and subscription status, and integrates with the existing control point infrastructure.
* Updated the configuration model (`TesiraDspPropertiesConfig`) to include a new `logicMeterControlBlocks` dictionary, and added the `TesiraLogicMeterBlockConfig` class to represent logic meter configuration. [[1]](diffhunk://#diff-08be830a3647268843e4bb812bf03a3e739f4c2bfdcf695072ed5677f267f5aaR43-R45) [[2]](diffhunk://#diff-08be830a3647268843e4bb812bf03a3e739f4c2bfdcf695072ed5677f267f5aaR316-R333)

**Integration with Tesira DSP Device**

* Added a `LogicMeters` dictionary to the `TesiraDsp` class, and updated initialization, object creation, and clearing logic to support logic meters. [[1]](diffhunk://#diff-f2fbfcc0bc06c368ecab0b6faff152fab85090776e9e8b7cac30bee525f0ca76R103-R104) [[2]](diffhunk://#diff-f2fbfcc0bc06c368ecab0b6faff152fab85090776e9e8b7cac30bee525f0ca76R207) [[3]](diffhunk://#diff-f2fbfcc0bc06c368ecab0b6faff152fab85090776e9e8b7cac30bee525f0ca76R333)
* Implemented the `CreateLogicMeters` method, which instantiates and registers logic meters based on configuration, and adds them to the control point list and device manager if enabled. [[1]](diffhunk://#diff-f2fbfcc0bc06c368ecab0b6faff152fab85090776e9e8b7cac30bee525f0ca76R476-R510) [[2]](diffhunk://#diff-f2fbfcc0bc06c368ecab0b6faff152fab85090776e9e8b7cac30bee525f0ca76R352-R353)

**Refactoring and Initialization**

* Moved the communication and monitor startup logic from a post-activation action into an `Initialize` override for improved lifecycle management. [[1]](diffhunk://#diff-f2fbfcc0bc06c368ecab0b6faff152fab85090776e9e8b7cac30bee525f0ca76L218-R231) [[2]](diffhunk://#diff-f2fbfcc0bc06c368ecab0b6faff152fab85090776e9e8b7cac30bee525f0ca76R252-R260)

These changes collectively add a new type of meter to the Tesira DSP integration, expanding monitoring capabilities and improving device flexibility.- **feat: Add Logic meter subscriptions**
- **fix: move connetion logic to initialize**
- **fix: use correct key format & clean up logging**
